### PR TITLE
eliminating the need to modify the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 #
 # Set your language preferences here
 #
-DEFAULT_LANGUAGE=en
-SUPPORTED_LANGUAGES=bg cs da de en es fi fy hu it ja no pl ru sq sk tr uk vn xx-lol zh-cn
+DEFAULT_LANGUAGE ?= en
+SUPPORTED_LANGUAGES ?= bg cs da de en es fi fy hu it ja no pl ru sq sk tr uk vn xx-lol zh-cn
 
 CC=cc
 CPP=cpp -C -P -E

--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,5 @@ accept-language.vcl: Makefile accept-language.c gen_vcl.pl
 test:
 	prove -I./t -v ./t
 
+clean:
+	$(RM) $(shell cat .gitignore)

--- a/README
+++ b/README
@@ -39,10 +39,12 @@ Requirements
 Instructions
 -------------
 
-1) Configure the list of languages your site supports
-   and the default fallback in the Makefile, *NOT* in the C code.
+1) Run 'make' informing the list of languages your site supports
+   and the default fallback in the command line, e.g.
 
-2) Run 'make && make test'
+   make DEFAULT_LANGUAGE=en SUPPORTED_LANGUAGES="en ja pt pt-br"
+
+2) Run 'make test'
    You should see "All tests successful" at the end of the execution
 
 3) Install the generated accept-language.vcl in /etc/varnish/


### PR DESCRIPTION
Hi,

I've made some changes to eliminate the need of chaning the Makefile. Please consider merging those back in your tree.

Also, I figured that it would be nice if I could call vanish-accept-language from any directory so that I could e.g. generate a .vcl file automatically during the build of my project. I am considering distributing a ready-to-use .vcl file with the code generated by varnish-accept-language ...

Maybe varnish-accept-language could be transforrmed in something that gets actually installed in the $PATH ... I would be willing to help with that.

What do you think about that?
